### PR TITLE
Fix event dispatcher shutdown

### DIFF
--- a/src/debezium_embedded/core.clj
+++ b/src/debezium_embedded/core.clj
@@ -17,8 +17,6 @@
   Closeable
   (close [this]
     (let [result (stop! this {})]
-      (when-let [shutdown (:shutdown (.-event-dispatcher this))]
-        (shutdown))
       (when result
         (throw (ex-info "Unable to stop Debezium capture" result))))))
 
@@ -82,6 +80,10 @@
 (defn- emit! [emit event]
   (when emit
     (emit event)))
+
+(defn- shutdown-event-dispatcher! [^CaptureHandle handle]
+  (when-let [shutdown (:shutdown (.-event-dispatcher handle))]
+    (shutdown)))
 
 (defn- observe-callback! [latest-event emit event]
   (reset! latest-event event)
@@ -217,26 +219,29 @@
   (let [completion (.-completion handle)
         start-result (.-start-result handle)
         timeout-ms (or timeout-ms (.-default-shutdown-timeout-ms handle))]
-    (cond
-      (not @(.-started? handle)) nil
-      (realized? completion) (completion-anomaly @completion)
-      :else
-      (try
-        (reset! (.-stop-requested? handle) true)
-        (if-not (realized? start-result)
-          (let [event @start-result]
-            (if (= ::polling-started (:event event))
-              (do
+    (try
+      (cond
+        (not @(.-started? handle)) nil
+        (realized? completion) (completion-anomaly @completion)
+        :else
+        (try
+          (reset! (.-stop-requested? handle) true)
+          (if-not (realized? start-result)
+            (let [event @start-result]
+              (if (= ::polling-started (:event event))
+                (do
+                  (close-engine! (.-engine handle)
+                                 (.-shutdown-issued? handle))
+                  (await-completion handle timeout-ms))
+                (start-anomaly event)))
+            (do
+              (when (polling? handle)
                 (close-engine! (.-engine handle)
-                               (.-shutdown-issued? handle))
-                (await-completion handle timeout-ms))
-              (start-anomaly event)))
-          (do
-            (when (polling? handle)
-              (close-engine! (.-engine handle)
-                             (.-shutdown-issued? handle)))
-            (await-completion handle timeout-ms)))
-        (catch Throwable cause
-          (let [event (fault ::shutdown-failed "Engine shutdown failed" cause)]
-            (emit! (:emit (.-event-dispatcher handle)) event)
-            (dissoc event :event)))))))
+                               (.-shutdown-issued? handle)))
+              (await-completion handle timeout-ms)))
+          (catch Throwable cause
+            (let [event (fault ::shutdown-failed "Engine shutdown failed" cause)]
+              (emit! (:emit (.-event-dispatcher handle)) event)
+              (dissoc event :event)))))
+      (finally
+        (shutdown-event-dispatcher! handle)))))

--- a/test/debezium_embedded/core_test.clj
+++ b/test/debezium_embedded/core_test.clj
@@ -176,6 +176,55 @@
     (deliver (.-start-result handle) {:event ::core/polling-started})
     (is (nil? (core/stop! handle {:timeout-ms 100})))))
 
+(deftest stop-shuts-down-the-event-dispatcher
+  (let [event-thread (promise)
+        dispatcher   (#'core/event-dispatcher
+                       (fn [_]
+                         (deliver event-thread (Thread/currentThread))))
+        completion   (promise)
+        engine       (reify java.io.Closeable
+                       (close [_]
+                         (deliver completion {:event ::core/completed
+                                              :success? true})))
+        handle       (debezium_embedded.core.CaptureHandle.
+                       engine
+                       (atom {:event ::core/polling-started})
+                       (doto (promise) (deliver {:event ::core/polling-started}))
+                       completion
+                       dispatcher
+                       (atom true)
+                       (atom false)
+                       (atom false)
+                       100)]
+    (try
+      ((:emit dispatcher) {:event ::test-event})
+      (let [^Thread thread (deref event-thread 1000 ::timed-out)]
+        (is (instance? Thread thread))
+        (is (false? (.isDaemon thread)))
+        (is (nil? (core/stop! handle {})))
+        (.join thread 1000)
+        (is (false? (.isAlive thread))))
+      (finally
+        ((:shutdown dispatcher))))))
+
+(deftest stop-shuts-down-the-event-dispatcher-before-start-and-after-an-anomaly
+  (let [shutdown-count (atom 0)
+        dispatcher     {:shutdown #(swap! shutdown-count inc)}
+        before-start   (debezium_embedded.core.CaptureHandle.
+                         nil (atom nil) (promise) (promise) dispatcher
+                         (atom false) (atom false) (atom false) 100)
+        failure        {:event                        ::core/completed
+                        :success?                     false
+                        :cognitect.anomalies/category :cognitect.anomalies/fault
+                        :cognitect.anomalies/message  "connector failed"}
+        after-anomaly  (debezium_embedded.core.CaptureHandle.
+                         nil (atom failure) (promise) (doto (promise) (deliver failure)) dispatcher
+                         (atom true) (atom false) (atom false) 100)]
+    (is (nil? (core/stop! before-start {})))
+    (is (= 1 @shutdown-count))
+    (is (= (dissoc failure :event :success?) (core/stop! after-anomaly {})))
+    (is (= 2 @shutdown-count))))
+
 (deftest stop-during-startup-closes-after-polling-starts
   (let [completion   (promise)
         close-count  (atom 0)


### PR DESCRIPTION
## What changed

- Shut down the event dispatcher from `stop!` on every return path.
- Keep `CaptureHandle.close` as a delegation to `stop!`.
- Add regression coverage for normal, anomalous, and not-started shutdowns.

## Why

The dispatcher owns a non-daemon worker. Previously only `Closeable.close` shut it down, while Integrant calls `stop!` directly. That left standalone processes alive after a normal halt.

## Validation

- `standard-clj check src/debezium_embedded/core.clj test/debezium_embedded/core_test.clj`
- `lein test`